### PR TITLE
Indicators view download service

### DIFF
--- a/src/main/java/com/geocat/ingester/dao/linkchecker/CapabilitiesDatasetMetadataLinkRepo.java
+++ b/src/main/java/com/geocat/ingester/dao/linkchecker/CapabilitiesDatasetMetadataLinkRepo.java
@@ -34,8 +34,133 @@
 package com.geocat.ingester.dao.linkchecker;
 
 import com.geocat.ingester.model.linkchecker.CapabilitiesDatasetMetadataLink;
+import com.geocat.ingester.model.linkchecker.helper.CapabilitiesLinkResult;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
 
 
 public interface CapabilitiesDatasetMetadataLinkRepo extends CrudRepository<CapabilitiesDatasetMetadataLink, Long> {
+    List<CapabilitiesDatasetMetadataLink> findByIdentity(String identity);
+
+    List<CapabilitiesDatasetMetadataLink> findBySha2NotNull();
+
+    @Query(value = "SELECT capabilitiesdocument.sha2, capabilitiesdocument.linkcheckjobid, capabilitiesdocument.capabilitiesdocumenttype\n" +
+            ",capabilitiesdatasetmetadatalink.ogclayername \n"+
+            "FROM capabilitiesdatasetmetadatalink\n" +
+            "      JOIN capabilitiesdocument ON (capabilitiesdocument.sha2=capabilitiesdatasetmetadatalink.cap_sha2 and capabilitiesdocument.linkcheckjobid = capabilitiesdatasetmetadatalink.linkcheckjobid)\n" +
+            "WHERE\n" +
+            "    capabilitiesdatasetmetadatalink.fileidentifier = ?1 \n" +
+            "    AND capabilitiesdatasetmetadatalink.datasetidentifier = ?2 \n"+
+            "    AND capabilitiesdatasetmetadatalink.linkcheckjobid = ?3 "
+            ,nativeQuery = true)
+    List<CapabilitiesLinkResult> linkToCapabilities(String fileidentifier, String datasetIdentifier, String linkcheckjobid);
+
+    //use this one if datasetid is null
+    @Query(value = "SELECT capabilitiesdocument.sha2, capabilitiesdocument.linkcheckjobid, capabilitiesdocument.capabilitiesdocumenttype\n" +
+            ",capabilitiesdatasetmetadatalink.ogclayername \n"+
+            "FROM capabilitiesdatasetmetadatalink\n" +
+            "      JOIN capabilitiesdocument ON (capabilitiesdocument.sha2=capabilitiesdatasetmetadatalink.cap_sha2 and capabilitiesdocument.linkcheckjobid = capabilitiesdatasetmetadatalink.linkcheckjobid)\n" +
+            "WHERE\n" +
+            "    capabilitiesdatasetmetadatalink.fileidentifier = ?1 \n" +
+            "    AND capabilitiesdatasetmetadatalink.linkcheckjobid = ?2 "
+            ,nativeQuery = true)
+    List<CapabilitiesLinkResult> linkToCapabilities(String fileidentifier, String linkcheckjobid);
+
+
+    @Query(value =   "SELECT\n" +
+            "    capabilitiesdocument.sha2,\n" +
+            "    capabilitiesdocument.linkcheckjobid,\n" +
+            "    capabilitiesdocument.capabilitiesdocumenttype ,\n" +
+            "    capabilitiesdatasetmetadatalink.ogclayername  \n" +
+            "FROM\n" +
+            "    capabilitiesdatasetmetadatalink        \n" +
+            "JOIN\n" +
+            "    datasetidentifier \n" +
+            "        ON (\n" +
+            "            datasetidentifier.capdatasetmetadatalink_capabilitiesdatasetmetadatalinkid = capabilitiesdatasetmetadatalink.capabilitiesdatasetmetadatalinkid \n" +
+            "        )        \n" +
+            "JOIN\n" +
+            "    capabilitiesdocument \n" +
+            "        ON (\n" +
+            "            capabilitiesdocument.sha2=capabilitiesdatasetmetadatalink.cap_sha2 \n" +
+            "            and capabilitiesdocument.linkcheckjobid = capabilitiesdatasetmetadatalink.linkcheckjobid\n" +
+            "        ) \n" +
+            "WHERE\n" +
+            "     datasetidentifier.datasetidentifierparenttype = 'CapDSMDLinkDatasetIdentifier' AND\n" +
+            "    datasetidentifier.code = ?2  \n" +
+            "    AND datasetidentifier.codespace IS NULL      \n" +
+            "    AND capabilitiesdatasetmetadatalink.cap_jobid = ?1 "
+            ,nativeQuery = true)
+    List<CapabilitiesLinkResult>  linkToCapabilitiesViaIdentifier_codeOnly(String linkCheckJobId, String metadata_code);
+
+    @Query(value =   "SELECT\n" +
+            "    capabilitiesdocument.sha2,\n" +
+            "    capabilitiesdocument.linkcheckjobid,\n" +
+            "    capabilitiesdocument.capabilitiesdocumenttype ,\n" +
+            "    capabilitiesdatasetmetadatalink.ogclayername  \n" +
+            "FROM\n" +
+            "    capabilitiesdatasetmetadatalink        \n" +
+            "JOIN\n" +
+            "    datasetidentifier \n" +
+            "        ON (\n" +
+            "            datasetidentifier.capdatasetmetadatalink_capabilitiesdatasetmetadatalinkid = capabilitiesdatasetmetadatalink.capabilitiesdatasetmetadatalinkid \n" +
+            "        )        \n" +
+            "JOIN\n" +
+            "    capabilitiesdocument \n" +
+            "        ON (\n" +
+            "            capabilitiesdocument.sha2=capabilitiesdatasetmetadatalink.cap_sha2 \n" +
+            "            and capabilitiesdocument.linkcheckjobid = capabilitiesdatasetmetadatalink.linkcheckjobid\n" +
+            "        ) \n" +
+            "WHERE\n" +
+            "     datasetidentifier.datasetidentifierparenttype = 'CapDSMDLinkDatasetIdentifier' AND\n" +
+            "    datasetidentifier.code = ?2  \n" +
+            "    AND datasetidentifier.codespace = ?3      \n" +
+            "    AND capabilitiesdatasetmetadatalink.cap_jobid = ?1 "
+            ,nativeQuery = true)
+    List<CapabilitiesLinkResult>  linkToCapabilitiesViaIdentifier_codeAndCodeSpace(String linkCheckJobId, String metadata_code,String metadata_codespace);
+
+
+    @Query(value =   "SELECT \n" +
+            "   capabilitiesdatasetmetadatalink.cap_sha2 as sha2,\n" +
+            "   capabilitiesdatasetmetadatalink.cap_jobid as linkcheckjobid, \n" +
+            "   capabilitiesdocument.capabilitiesdocumenttype,  \n" +
+            "   capabilitiesdatasetmetadatalink.ogclayername   \n" +
+            "\n" +
+            "FROM  \n" +
+            "     capabilitiesdatasetmetadatalink         \n" +
+            "    JOIN \n" +
+            "       capabilitiesdocument  \n" +
+            "             ON ( \n" +
+            "                 capabilitiesdocument.sha2=capabilitiesdatasetmetadatalink.cap_sha2  \n" +
+            "                 and capabilitiesdocument.linkcheckjobid = capabilitiesdatasetmetadatalink.linkcheckjobid \n" +
+            "                )  \n" +
+            "WHERE\n" +
+            "     capabilitiesdatasetmetadatalink.identity = ?2 \n" +
+            "  AND capabilitiesdatasetmetadatalink.cap_jobid = ?1\n"
+            ,nativeQuery = true)
+    List<CapabilitiesLinkResult> linkToCapabilitiesLayerViaIdentifier(String linkCheckJobId, String DSIDcode);
+
+    @Query(value =   "SELECT \n" +
+            "   capabilitiesdatasetmetadatalink.cap_sha2 as sha2,\n" +
+            "   capabilitiesdatasetmetadatalink.cap_jobid as linkcheckjobid, \n" +
+            "   capabilitiesdocument.capabilitiesdocumenttype,  \n" +
+            "   capabilitiesdatasetmetadatalink.ogclayername   \n" +
+            "\n" +
+            "FROM  \n" +
+            "     capabilitiesdatasetmetadatalink         \n" +
+            "    JOIN \n" +
+            "       capabilitiesdocument  \n" +
+            "             ON ( \n" +
+            "                 capabilitiesdocument.sha2=capabilitiesdatasetmetadatalink.cap_sha2  \n" +
+            "                 and capabilitiesdocument.linkcheckjobid = capabilitiesdatasetmetadatalink.linkcheckjobid \n" +
+            "                )  \n" +
+            "WHERE\n" +
+            "     capabilitiesdatasetmetadatalink.identity = ?2 \n" +
+            "  AND (capabilitiesdatasetmetadatalink.authority = ?3 OR capabilitiesdatasetmetadatalink.authorityname = ?3)   \n" +
+            "  AND capabilitiesdatasetmetadatalink.cap_jobid = ?1\n"
+            ,nativeQuery = true)
+    List<CapabilitiesLinkResult> linkToCapabilitiesLayerViaIdentifier(String linkCheckJobId, String DSIDcode, String DSIDcodespace);
+
 }

--- a/src/main/java/com/geocat/ingester/dao/linkchecker/CapabilitiesDocumentRepo.java
+++ b/src/main/java/com/geocat/ingester/dao/linkchecker/CapabilitiesDocumentRepo.java
@@ -35,7 +35,9 @@ package com.geocat.ingester.dao.linkchecker;
 
 import com.geocat.ingester.model.linkchecker.CapabilitiesDocument;
 import com.geocat.ingester.model.linkchecker.helper.CapabilitiesType;
+import com.geocat.ingester.model.linkchecker.helper.SHA2JobIdCompositeKey;
 import org.springframework.context.annotation.Scope;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Component;
 
@@ -43,8 +45,11 @@ import java.util.List;
 
 @Component
 @Scope("prototype")
-public interface CapabilitiesDocumentRepo extends CrudRepository<CapabilitiesDocument, Long> {
+public interface CapabilitiesDocumentRepo extends CrudRepository<CapabilitiesDocument, SHA2JobIdCompositeKey> {
 
     List<CapabilitiesDocument> findByCapabilitiesDocumentType(CapabilitiesType type);
+
+
+    List<CapabilitiesDocument> findByLinkCheckJobId(String linkCheckJobId);
 
 }

--- a/src/main/java/com/geocat/ingester/dao/linkchecker/DatasetDocumentLinkRepo.java
+++ b/src/main/java/com/geocat/ingester/dao/linkchecker/DatasetDocumentLinkRepo.java
@@ -31,54 +31,20 @@
  *  ==============================================================================
  */
 
-package com.geocat.ingester.model.linkchecker;
+package com.geocat.ingester.dao.linkchecker;
 
-import com.geocat.ingester.model.linkchecker.helper.DatasetMetadataRecord;
-import com.geocat.ingester.model.linkchecker.helper.OGCLinkToData;
+import com.geocat.ingester.model.linkchecker.DatasetDocumentLink;
+import org.springframework.context.annotation.Scope;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Component;
 
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
-
-
-/**
- * Represents a simple linkage between a dataset and layer in an OGC service (WFS/WMS/WMTS).
- *
- *     The service (capabilities) can be found using capabilitiesSha2,linkCheckJobId.
- *     The layer is in ogcLayerName.
- *
- *     In the capabilities file, you should find a layer/featuretype (Name=ogcLayerName) that has a metadataURL
- *     that points the Dataset Metadata document (via fileIdentifier and datasetIdentifier).
- *
- */
-@Entity
-@DiscriminatorValue("SimpleLayerMetadataUrlDataLink")
-public class SimpleLayerMetadataUrlDataLink extends OGCLinkToData {
+import java.util.List;
 
 
-    public SimpleLayerMetadataUrlDataLink() {
-        super();
-    }
+@Component
+@Scope("prototype")
+public interface DatasetDocumentLinkRepo extends CrudRepository<DatasetDocumentLink, Long> {
 
-    public SimpleLayerMetadataUrlDataLink(String linkcheckjobid, String sha2, String capabilitiesdocumenttype, DatasetMetadataRecord datasetMetadataRecord) {
-        super(linkcheckjobid,sha2,capabilitiesdocumenttype,datasetMetadataRecord);
-    }
+    List<DatasetDocumentLink> findByLinkCheckJobIdAndSha2(String linkCheckJobId, String Sha2);
 
-    //---
-
-
-    //----
-
-
-    @Override
-    public String toString() {
-        return "SimpleLayerMetadataUrlDataLink{\n" +
-                "     ogcLayerName:" + getOgcLayerName() + '\n' +
-                super.toString() +
-                '}';
-    }
-
-    @Override
-    public String key() {
-        return super.key() +"::"+getOgcLayerName();
-    }
 }

--- a/src/main/java/com/geocat/ingester/dao/linkchecker/LinkCheckJobRepo.java
+++ b/src/main/java/com/geocat/ingester/dao/linkchecker/LinkCheckJobRepo.java
@@ -50,4 +50,6 @@ public interface LinkCheckJobRepo extends CrudRepository<LinkCheckJob, String> {
 
     @Query("SELECT l FROM LinkCheckJob l WHERE l.harvestJobId = :harvestJobId AND l.createTimeUTC = (SELECT max(l2.createTimeUTC) FROM LinkCheckJob l2 WHERE l2.harvestJobId = :harvestJobId AND l2.state = 'COMPLETE')")
     Optional<LinkCheckJob> findByHarvestJobId(@Param("harvestJobId") String harvestJobId);
+
+    List<LinkCheckJob> findByLongTermTag(String longTermTag);
 }

--- a/src/main/java/com/geocat/ingester/dao/linkchecker/LinkToDataRepo.java
+++ b/src/main/java/com/geocat/ingester/dao/linkchecker/LinkToDataRepo.java
@@ -33,19 +33,17 @@
 
 package com.geocat.ingester.dao.linkchecker;
 
-import com.geocat.ingester.model.linkchecker.LinkCheckJob;
-import com.geocat.ingester.model.linkchecker.ServiceDocumentLink;
+
+import com.geocat.ingester.model.linkchecker.helper.LinkToData;
 import org.springframework.context.annotation.Scope;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
-
+import java.util.List;
 
 @Component
 @Scope("prototype")
-public interface ServiceDocumentLinkRepo extends CrudRepository<ServiceDocumentLink, Long> {
+public interface LinkToDataRepo extends CrudRepository<LinkToData, Long> {
 
-    Optional<ServiceDocumentLink> findFirstByLinkCheckJobIdAndSha2(String linkCheckJobId, String sha2);
-
+    List<LinkToData> findAllByLinkCheckJobIdAndDatasetMetadataFileIdentifier(String linkCheckJobId, String datasetMetadataFileIdentifier);
 }

--- a/src/main/java/com/geocat/ingester/dao/linkchecker/LinkToDataRepo.java
+++ b/src/main/java/com/geocat/ingester/dao/linkchecker/LinkToDataRepo.java
@@ -46,4 +46,7 @@ import java.util.List;
 public interface LinkToDataRepo extends CrudRepository<LinkToData, Long> {
 
     List<LinkToData> findAllByLinkCheckJobIdAndDatasetMetadataFileIdentifier(String linkCheckJobId, String datasetMetadataFileIdentifier);
+
+    List<LinkToData> findByLinkCheckJobIdAndCapabilitiesSha2(String linkCheckJobId, String sha2);
+    List<LinkToData> findByLinkCheckJobId(String linkCheckJobId);
 }

--- a/src/main/java/com/geocat/ingester/dao/linkchecker/LocalDatasetMetadataRecordRepo.java
+++ b/src/main/java/com/geocat/ingester/dao/linkchecker/LocalDatasetMetadataRecordRepo.java
@@ -35,11 +35,14 @@ package com.geocat.ingester.dao.linkchecker;
 
 
 import com.geocat.ingester.model.linkchecker.LocalDatasetMetadataRecord;
+import com.geocat.ingester.model.linkchecker.helper.ServiceMetadataDocumentState;
 import com.geocat.ingester.model.linkchecker.helper.StatusQueryItem;
 import org.springframework.context.annotation.Scope;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -48,7 +51,30 @@ import java.util.List;
 @Scope("prototype")
 public interface LocalDatasetMetadataRecordRepo extends CrudRepository<LocalDatasetMetadataRecord, Long> {
 
-    List<LocalDatasetMetadataRecord> findAllByFileIdentifierAndLinkCheckJobId(String fileIdentifier, String linkCheckJobId);
+    @Transactional
+    @Modifying
+    @Query(value="UPDATE LocalDatasetMetadataRecord ldmr SET ldmr.state = :newState WHERE ldmr.datasetMetadataDocumentId = :id ")
+    void updateState(long id, ServiceMetadataDocumentState newState);
+
+    @Transactional
+    @Modifying
+    @Query(value="UPDATE LocalDatasetMetadataRecord ldmr SET ldmr.state = :newState WHERE ldmr.datasetMetadataDocumentId = :id and (ldmr.state <> 'NOT_APPLICABLE')")
+    void updateStateNotNotApplicatable(long id, ServiceMetadataDocumentState newState);
+
+    LocalDatasetMetadataRecord findFirstByFileIdentifierAndLinkCheckJobId(String fileID,String linkCheckJobId);
+
+    LocalDatasetMetadataRecord findFirstByFileIdentifier(String fileID);
+
+    List<LocalDatasetMetadataRecord> findByFileIdentifierAndLinkCheckJobId(String fileID,String linkCheckJobId);
+
+    List<LocalDatasetMetadataRecord> findByFileIdentifier(String fileID);
+
+
+    @Query(value = "SELECT datasetmetadatadocumentid FROM datasetmetadatarecord   WHERE linkcheckjobid = ?1",
+            nativeQuery = true
+    )
+    List<Long> searchAllDatasetIds(String linkCheckJobId);
+
 
     LocalDatasetMetadataRecord findFirstByLinkCheckJobIdAndSha2(String linkCheckJobId, String sha2);
 

--- a/src/main/java/com/geocat/ingester/dao/linkchecker/LocalServiceMetadataRecordRepo.java
+++ b/src/main/java/com/geocat/ingester/dao/linkchecker/LocalServiceMetadataRecordRepo.java
@@ -34,11 +34,14 @@
 package com.geocat.ingester.dao.linkchecker;
 
 import com.geocat.ingester.model.linkchecker.LocalServiceMetadataRecord;
+import com.geocat.ingester.model.linkchecker.helper.ServiceMetadataDocumentState;
 import com.geocat.ingester.model.linkchecker.helper.StatusQueryItem;
 import org.springframework.context.annotation.Scope;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -47,13 +50,34 @@ import java.util.List;
 @Scope("prototype")
 public interface LocalServiceMetadataRecordRepo extends CrudRepository<LocalServiceMetadataRecord, Long> {
 
+    @Transactional
+    @Modifying
+    @Query(value="UPDATE LocalServiceMetadataRecord lsmr SET lsmr.state = :newState WHERE lsmr.serviceMetadataDocumentId = :id ")
+    void updateState(long id, ServiceMetadataDocumentState newState);
 
+    @Transactional
+    @Modifying
+    @Query(value="UPDATE LocalServiceMetadataRecord lsmr SET lsmr.state = :newState WHERE lsmr.serviceMetadataDocumentId = :id and (lsmr.state <> 'NOT_APPLICABLE')")
+    void updateStateNotApplicable(long id, ServiceMetadataDocumentState newState);
 
-    List<LocalServiceMetadataRecord> findAllByFileIdentifierAndLinkCheckJobId(String fileIdentifier, String linkCheckJobId);
 
     LocalServiceMetadataRecord findFirstByLinkCheckJobIdAndSha2(String linkCheckJobId, String sha2);
 
     List<LocalServiceMetadataRecord> findByLinkCheckJobId(String linkCheckJobId);
+
+    LocalServiceMetadataRecord findFirstByFileIdentifierAndLinkCheckJobId(String fileID,String linkCheckJobId);
+
+    List<LocalServiceMetadataRecord> findByFileIdentifierAndLinkCheckJobId(String fileID,String linkCheckJobId);
+
+    LocalServiceMetadataRecord findFirstByFileIdentifier(String fileID);
+
+    List<LocalServiceMetadataRecord> findByFileIdentifier(String fileID);
+
+
+    @Query(value = "SELECT servicemetadatadocumentid FROM servicemetadatarecord   WHERE linkcheckjobid = ?1",
+            nativeQuery = true
+    )
+    List<Long> searchAllServiceIds(String linkCheckJobId);
 
 
     long countByLinkCheckJobId(String LinkCheckJobId);

--- a/src/main/java/com/geocat/ingester/dao/linkchecker/ServiceDocumentLinkRepo.java
+++ b/src/main/java/com/geocat/ingester/dao/linkchecker/ServiceDocumentLinkRepo.java
@@ -39,6 +39,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -48,4 +49,5 @@ public interface ServiceDocumentLinkRepo extends CrudRepository<ServiceDocumentL
 
     Optional<ServiceDocumentLink> findFirstByLinkCheckJobIdAndSha2(String linkCheckJobId, String sha2);
 
+    List<ServiceDocumentLink> findByLinkCheckJobIdAndSha2(String linkCheckJobId, String Sha2);
 }

--- a/src/main/java/com/geocat/ingester/dao/metadata/MetadataIndicatorRepository.java
+++ b/src/main/java/com/geocat/ingester/dao/metadata/MetadataIndicatorRepository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package com.geocat.ingester.dao.metadata;
+
+import com.geocat.ingester.model.metadata.MetadataIndicator;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.Optional;
+
+/**
+ * Data Access object for the {@link MetadataIndicator} entities.
+ */
+public interface MetadataIndicatorRepository extends JpaRepository<MetadataIndicator, Integer>, JpaSpecificationExecutor<MetadataIndicator> {
+
+    Optional<MetadataIndicator> findMetadataIndicatorByName(String name);
+}

--- a/src/main/java/com/geocat/ingester/model/linkchecker/AtomActualDataEntry.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/AtomActualDataEntry.java
@@ -1,0 +1,127 @@
+/*
+ *  =============================================================================
+ *  ===  Copyright (C) 2021 Food and Agriculture Organization of the
+ *  ===  United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ *  ===  and United Nations Environment Programme (UNEP)
+ *  ===
+ *  ===  This program is free software; you can redistribute it and/or modify
+ *  ===  it under the terms of the GNU General Public License as published by
+ *  ===  the Free Software Foundation; either version 2 of the License, or (at
+ *  ===  your option) any later version.
+ *  ===
+ *  ===  This program is distributed in the hope that it will be useful, but
+ *  ===  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  ===  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  ===  General Public License for more details.
+ *  ===
+ *  ===  You should have received a copy of the GNU General Public License
+ *  ===  along with this program; if not, write to the Free Software
+ *  ===  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *  ===
+ *  ===  Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ *  ===  Rome - Italy. email: geonetwork@osgeo.org
+ *  ===
+ *  ===  Development of this program was financed by the European Union within
+ *  ===  Service Contract NUMBER – 941143 – IPR – 2021 with subject matter
+ *  ===  "Facilitating a sustainable evolution and maintenance of the INSPIRE
+ *  ===  Geoportal", performed in the period 2021-2023.
+ *  ===
+ *  ===  Contact: JRC Unit B.6 Digital Economy, Via Enrico Fermi 2749,
+ *  ===  21027 Ispra, Italy. email: JRC-INSPIRE-SUPPORT@ec.europa.eu
+ *  ==============================================================================
+ */
+
+package com.geocat.ingester.model.linkchecker;
+
+import com.geocat.ingester.model.linkchecker.helper.AtomDataRequest;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+public class AtomActualDataEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private long atomActualDataEntryId;
+
+    Integer index;
+
+    @ManyToOne(fetch = FetchType.EAGER,cascade = {CascadeType.PERSIST,CascadeType.MERGE})
+    SimpleAtomLinkToData simpleAtomLinkToData;
+
+    @Column(columnDefinition = "text")
+    String entryId;
+
+    Boolean successfullyDownloaded;
+
+    @OneToMany(
+            cascade = {CascadeType.ALL}, fetch = FetchType.EAGER, mappedBy = "atomActualDataEntry")
+    @Fetch(value = FetchMode.SUBSELECT)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+  //  @JoinColumn(name = "atomDataRequestId")
+    List<AtomDataRequest> atomDataRequestList;
+
+    //--
+
+    public AtomActualDataEntry() {
+
+    }
+
+    //--
+
+
+    public Boolean getSuccessfullyDownloaded() {
+        return successfullyDownloaded;
+    }
+
+    public void setSuccessfullyDownloaded(Boolean successfullyDownloaded) {
+        this.successfullyDownloaded = successfullyDownloaded;
+    }
+
+    public int getIndex() {
+        return (index == null)? 0 : index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public SimpleAtomLinkToData getSimpleAtomLinkToData() {
+        return simpleAtomLinkToData;
+    }
+
+    public void setSimpleAtomLinkToData(SimpleAtomLinkToData simpleAtomLinkToData) {
+        this.simpleAtomLinkToData = simpleAtomLinkToData;
+    }
+
+    public String getEntryId() {
+        return entryId;
+    }
+
+    public void setEntryId(String entryId) {
+        this.entryId = entryId;
+    }
+
+    public List<AtomDataRequest> getAtomDataRequestList() {
+        return atomDataRequestList;
+    }
+
+    public void setAtomDataRequestList(List<AtomDataRequest> atomDataRequestList) {
+        this.atomDataRequestList = atomDataRequestList;
+    }
+
+    public long getAtomActualDataEntryId() {
+        return atomActualDataEntryId;
+    }
+
+    public void setAtomActualDataEntryId(long atomActualDataEntryId) {
+        this.atomActualDataEntryId = atomActualDataEntryId;
+    }
+
+    //--
+}

--- a/src/main/java/com/geocat/ingester/model/linkchecker/AtomActualDataEntry.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/AtomActualDataEntry.java
@@ -33,21 +33,51 @@
 
 package com.geocat.ingester.model.linkchecker;
 
+import com.geocat.ingester.model.linkchecker.SimpleAtomLinkToData;
 import com.geocat.ingester.model.linkchecker.helper.AtomDataRequest;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import java.util.List;
 
+@Table(
+        indexes = {
+                @Index(
+                        name = "AtomActualDataEntry_link2data_idx",
+                        columnList = "simpleatomlinktodata_linktodataid",
+                        unique = false
+                ),
+                @Index(
+                        name = "AtomActualDataEntry_linkcheckjobid_idx",
+                        columnList = "linkcheckjobid",
+                        unique = false
+                ),
+        })
 @Entity
 public class AtomActualDataEntry {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private long atomActualDataEntryId;
+
+
+    @Column(columnDefinition = "varchar(40)")
+    private String linkCheckJobId;
+
 
     Integer index;
 
@@ -62,8 +92,8 @@ public class AtomActualDataEntry {
     @OneToMany(
             cascade = {CascadeType.ALL}, fetch = FetchType.EAGER, mappedBy = "atomActualDataEntry")
     @Fetch(value = FetchMode.SUBSELECT)
-    @OnDelete(action = OnDeleteAction.CASCADE)
-  //  @JoinColumn(name = "atomDataRequestId")
+    // @OnDelete(action = OnDeleteAction.CASCADE)
+    //  @JoinColumn(name = "atomDataRequestId")
     List<AtomDataRequest> atomDataRequestList;
 
     //--
@@ -74,6 +104,18 @@ public class AtomActualDataEntry {
 
     //--
 
+
+    public String getLinkCheckJobId() {
+        return linkCheckJobId;
+    }
+
+    public void setLinkCheckJobId(String linkCheckJobId) {
+        this.linkCheckJobId = linkCheckJobId;
+    }
+
+    public void setIndex(Integer index) {
+        this.index = index;
+    }
 
     public Boolean getSuccessfullyDownloaded() {
         return successfullyDownloaded;

--- a/src/main/java/com/geocat/ingester/model/linkchecker/DatasetDocumentLink.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/DatasetDocumentLink.java
@@ -49,6 +49,11 @@ import javax.persistence.*;
                         name = "datasetmetadatarecord_datasetmetadatadocumentid_index",
                         columnList = "datasetMetadataRecord_datasetMetadataDocumentId",
                         unique = false
+                ),
+                @Index(
+                        name = "datasetmetadatarecord_linkCheckJobIdsha2_index",
+                        columnList = "linkcheckjobid,sha2",
+                        unique = false
                 )
         }
 )

--- a/src/main/java/com/geocat/ingester/model/linkchecker/OGCRequest.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/OGCRequest.java
@@ -1,0 +1,134 @@
+/*
+ *  =============================================================================
+ *  ===  Copyright (C) 2021 Food and Agriculture Organization of the
+ *  ===  United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ *  ===  and United Nations Environment Programme (UNEP)
+ *  ===
+ *  ===  This program is free software; you can redistribute it and/or modify
+ *  ===  it under the terms of the GNU General Public License as published by
+ *  ===  the Free Software Foundation; either version 2 of the License, or (at
+ *  ===  your option) any later version.
+ *  ===
+ *  ===  This program is distributed in the hope that it will be useful, but
+ *  ===  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  ===  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  ===  General Public License for more details.
+ *  ===
+ *  ===  You should have received a copy of the GNU General Public License
+ *  ===  along with this program; if not, write to the Free Software
+ *  ===  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *  ===
+ *  ===  Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ *  ===  Rome - Italy. email: geonetwork@osgeo.org
+ *  ===
+ *  ===  Development of this program was financed by the European Union within
+ *  ===  Service Contract NUMBER – 941143 – IPR – 2021 with subject matter
+ *  ===  "Facilitating a sustainable evolution and maintenance of the INSPIRE
+ *  ===  Geoportal", performed in the period 2021-2023.
+ *  ===
+ *  ===  Contact: JRC Unit B.6 Digital Economy, Via Enrico Fermi 2749,
+ *  ===  21027 Ispra, Italy. email: JRC-INSPIRE-SUPPORT@ec.europa.eu
+ *  ==============================================================================
+ */
+
+package com.geocat.ingester.model.linkchecker;
+
+import com.geocat.ingester.model.linkchecker.helper.HTTPRequestCheckerType;
+import com.geocat.ingester.model.linkchecker.helper.RetrievableSimpleLink;
+
+import javax.persistence.*;
+
+import static com.geocat.ingester.model.linkchecker.helper.PartialDownloadHint.ALWAYS_PARTIAL;
+
+@Entity
+
+public class OGCRequest extends RetrievableSimpleLink {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private long ogcRequestId;
+
+    Boolean successfulOGCRequest;
+
+//    @OneToOne(mappedBy = "ogcRequest")
+//    OGCLinkToData linkToData;
+
+
+    @Column(columnDefinition = "text")
+    String summary;
+
+    @Enumerated(EnumType.STRING)
+    HTTPRequestCheckerType httpRequestCheckerType;
+
+    @Column(columnDefinition = "text")
+    String  unSuccessfulOGCRequestReason;
+
+    public OGCRequest() {
+        super();
+        setPartialDownloadHint(ALWAYS_PARTIAL);
+    }
+
+    public OGCRequest(String url, HTTPRequestCheckerType httpRequestCheckerType) {
+        this();
+        setRawURL(url);
+        setFixedURL(url);
+        setHttpRequestCheckerType(httpRequestCheckerType);
+    }
+
+    public Boolean isSuccessfulOGCRequest() {
+        return successfulOGCRequest;
+    }
+
+    public void setSuccessfulOGCRequest(Boolean successfulOGCRequest) {
+        this.successfulOGCRequest = successfulOGCRequest;
+    }
+
+    public String getUnSuccessfulOGCRequestReason() {
+        return unSuccessfulOGCRequestReason;
+    }
+
+    public void setUnSuccessfulOGCRequestReason(String unSuccessfulOGCRequestReason) {
+        this.unSuccessfulOGCRequestReason = unSuccessfulOGCRequestReason;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    public HTTPRequestCheckerType getHttpRequestCheckerType() {
+        return httpRequestCheckerType;
+    }
+
+    public void setHttpRequestCheckerType(HTTPRequestCheckerType httpRequestCheckerType) {
+        this.httpRequestCheckerType = httpRequestCheckerType;
+    }
+
+    public long getOgcRequestId() {
+        return ogcRequestId;
+    }
+
+    public void setOgcRequestId(long ogcRequestId) {
+        this.ogcRequestId = ogcRequestId;
+    }
+//
+//    public OGCLinkToData getLinkToData() {
+//        return linkToData;
+//    }
+//
+//    public void setLinkToData(OGCLinkToData linkToData) {
+//        this.linkToData = linkToData;
+//    }
+
+    @Override
+    public String toString() {
+        return "OGCRequest{\n      summary:" + summary +"\n " +
+                "    successfulOGCRequest=" + successfulOGCRequest +
+                "\n      unSuccessfulOGCRequestReason='" + unSuccessfulOGCRequestReason + '\'' + '\n'
+                + super.toString() +
+                "\n}";
+    }
+}

--- a/src/main/java/com/geocat/ingester/model/linkchecker/OGCRequest.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/OGCRequest.java
@@ -36,12 +36,28 @@ package com.geocat.ingester.model.linkchecker;
 import com.geocat.ingester.model.linkchecker.helper.HTTPRequestCheckerType;
 import com.geocat.ingester.model.linkchecker.helper.RetrievableSimpleLink;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
 import static com.geocat.ingester.model.linkchecker.helper.PartialDownloadHint.ALWAYS_PARTIAL;
 
-@Entity
 
+@Entity
+@Table(
+        indexes = {
+                @Index(
+                        name = "OGCRequest_linkcheckjobid_idx",
+                        columnList = "linkcheckjobid",
+                        unique = false
+                )})
 public class OGCRequest extends RetrievableSimpleLink {
 
     @Id
@@ -68,7 +84,7 @@ public class OGCRequest extends RetrievableSimpleLink {
         setPartialDownloadHint(ALWAYS_PARTIAL);
     }
 
-    public OGCRequest(String url, HTTPRequestCheckerType httpRequestCheckerType) {
+    public OGCRequest(String url,HTTPRequestCheckerType httpRequestCheckerType) {
         this();
         setRawURL(url);
         setFixedURL(url);

--- a/src/main/java/com/geocat/ingester/model/linkchecker/ServiceDocumentLink.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/ServiceDocumentLink.java
@@ -49,6 +49,11 @@ import javax.persistence.*;
                         name = "servicemetadatarecord_servicemetadatadocumentid_index",
                         columnList = "serviceMetadataRecord_serviceMetadataDocumentId",
                         unique = false
+                ),
+                @Index(
+                        name = "servicemetadatarecord_linkCheckJobIdsha2_index",
+                        columnList = "linkcheckjobid,sha2",
+                        unique = false
                 )
         }
 )

--- a/src/main/java/com/geocat/ingester/model/linkchecker/SimpleAtomLinkToData.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/SimpleAtomLinkToData.java
@@ -41,7 +41,15 @@ import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinColumns;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import java.util.List;
 
 @Entity
@@ -55,13 +63,13 @@ public class SimpleAtomLinkToData extends LinkToData {
     String context;
 
     @OneToOne(cascade = CascadeType.ALL)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    // @OnDelete(action = OnDeleteAction.CASCADE)
     AtomSubFeedRequest atomSubFeedRequest;
 
     @OneToMany(
             cascade = {CascadeType.ALL}, fetch = FetchType.EAGER, mappedBy = "simpleAtomLinkToData")
     @Fetch(value = FetchMode.SUBSELECT)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    //  @OnDelete(action = OnDeleteAction.CASCADE)
     List<AtomActualDataEntry> atomActualDataEntryList;
 
     public SimpleAtomLinkToData() {

--- a/src/main/java/com/geocat/ingester/model/linkchecker/SimpleAtomLinkToData.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/SimpleAtomLinkToData.java
@@ -1,0 +1,118 @@
+/*
+ *  =============================================================================
+ *  ===  Copyright (C) 2021 Food and Agriculture Organization of the
+ *  ===  United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ *  ===  and United Nations Environment Programme (UNEP)
+ *  ===
+ *  ===  This program is free software; you can redistribute it and/or modify
+ *  ===  it under the terms of the GNU General Public License as published by
+ *  ===  the Free Software Foundation; either version 2 of the License, or (at
+ *  ===  your option) any later version.
+ *  ===
+ *  ===  This program is distributed in the hope that it will be useful, but
+ *  ===  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  ===  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  ===  General Public License for more details.
+ *  ===
+ *  ===  You should have received a copy of the GNU General Public License
+ *  ===  along with this program; if not, write to the Free Software
+ *  ===  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *  ===
+ *  ===  Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ *  ===  Rome - Italy. email: geonetwork@osgeo.org
+ *  ===
+ *  ===  Development of this program was financed by the European Union within
+ *  ===  Service Contract NUMBER – 941143 – IPR – 2021 with subject matter
+ *  ===  "Facilitating a sustainable evolution and maintenance of the INSPIRE
+ *  ===  Geoportal", performed in the period 2021-2023.
+ *  ===
+ *  ===  Contact: JRC Unit B.6 Digital Economy, Via Enrico Fermi 2749,
+ *  ===  21027 Ispra, Italy. email: JRC-INSPIRE-SUPPORT@ec.europa.eu
+ *  ==============================================================================
+ */
+
+package com.geocat.ingester.model.linkchecker;
+
+import com.geocat.ingester.model.linkchecker.helper.AtomSubFeedRequest;
+import com.geocat.ingester.model.linkchecker.helper.DatasetMetadataRecord;
+import com.geocat.ingester.model.linkchecker.helper.LinkToData;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@DiscriminatorValue("SimpleAtomLinkToData")
+public class SimpleAtomLinkToData extends LinkToData {
+
+    @Column(columnDefinition = "text")
+    String layerId;
+
+    @Column(columnDefinition = "text")
+    String context;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    AtomSubFeedRequest atomSubFeedRequest;
+
+    @OneToMany(
+            cascade = {CascadeType.ALL}, fetch = FetchType.EAGER, mappedBy = "simpleAtomLinkToData")
+    @Fetch(value = FetchMode.SUBSELECT)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    List<AtomActualDataEntry> atomActualDataEntryList;
+
+    public SimpleAtomLinkToData() {
+        super();
+    }
+
+    public SimpleAtomLinkToData(String linkcheckjobid, String sha2, String capabilitiesdocumenttype, DatasetMetadataRecord datasetMetadataRecord, String layerName) {
+        super(linkcheckjobid,sha2,capabilitiesdocumenttype,datasetMetadataRecord);
+        this.layerId = layerName;
+    }
+
+    //---
+
+
+    public List<AtomActualDataEntry> getAtomActualDataEntryList() {
+        return atomActualDataEntryList;
+    }
+
+    public void setAtomActualDataEntryList(List<AtomActualDataEntry> atomActualDataEntryList) {
+        this.atomActualDataEntryList = atomActualDataEntryList;
+    }
+
+    public String getLayerId() {
+        return layerId;
+    }
+
+    public void setLayerId(String layerId) {
+        this.layerId = layerId;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
+    }
+
+    public AtomSubFeedRequest getAtomSubFeedRequest() {
+        return atomSubFeedRequest;
+    }
+
+    public void setAtomSubFeedRequest(AtomSubFeedRequest atomSubFeedRequest) {
+        this.atomSubFeedRequest = atomSubFeedRequest;
+    }
+
+
+    //---
+
+    @Override
+    public String key() {
+        return super.key() +"::"+layerId;
+    }
+}

--- a/src/main/java/com/geocat/ingester/model/linkchecker/SimpleLayerDatasetIdDataLink.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/SimpleLayerDatasetIdDataLink.java
@@ -33,8 +33,6 @@
 
 package com.geocat.ingester.model.linkchecker;
 
-
-
 import com.geocat.ingester.model.linkchecker.helper.DatasetMetadataRecord;
 import com.geocat.ingester.model.linkchecker.helper.OGCLinkToData;
 

--- a/src/main/java/com/geocat/ingester/model/linkchecker/SimpleLayerDatasetIdDataLink.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/SimpleLayerDatasetIdDataLink.java
@@ -1,0 +1,106 @@
+/*
+ *  =============================================================================
+ *  ===  Copyright (C) 2021 Food and Agriculture Organization of the
+ *  ===  United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ *  ===  and United Nations Environment Programme (UNEP)
+ *  ===
+ *  ===  This program is free software; you can redistribute it and/or modify
+ *  ===  it under the terms of the GNU General Public License as published by
+ *  ===  the Free Software Foundation; either version 2 of the License, or (at
+ *  ===  your option) any later version.
+ *  ===
+ *  ===  This program is distributed in the hope that it will be useful, but
+ *  ===  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  ===  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  ===  General Public License for more details.
+ *  ===
+ *  ===  You should have received a copy of the GNU General Public License
+ *  ===  along with this program; if not, write to the Free Software
+ *  ===  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *  ===
+ *  ===  Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ *  ===  Rome - Italy. email: geonetwork@osgeo.org
+ *  ===
+ *  ===  Development of this program was financed by the European Union within
+ *  ===  Service Contract NUMBER – 941143 – IPR – 2021 with subject matter
+ *  ===  "Facilitating a sustainable evolution and maintenance of the INSPIRE
+ *  ===  Geoportal", performed in the period 2021-2023.
+ *  ===
+ *  ===  Contact: JRC Unit B.6 Digital Economy, Via Enrico Fermi 2749,
+ *  ===  21027 Ispra, Italy. email: JRC-INSPIRE-SUPPORT@ec.europa.eu
+ *  ==============================================================================
+ */
+
+package com.geocat.ingester.model.linkchecker;
+
+
+
+import com.geocat.ingester.model.linkchecker.helper.DatasetMetadataRecord;
+import com.geocat.ingester.model.linkchecker.helper.OGCLinkToData;
+
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+/**
+ * This represents WMS, WMTS, and Atom "layers" that have an attached DatasetID
+ *  WMS/WMTS: Identity and AuthorityURL
+ *  Atom: InspireSpatialDatasetCode and Codespace
+ *
+ *  WMS/WMTS:
+ *
+ *   <AuthorityURL name="ABC">
+ *      <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="URL" xlink:type="simple"/>
+ *   </AuthorityURL>
+ *    <Identifier authority="ABC">DatasetCODE</Identifier>
+ *
+ *    Atom:
+ *      <inspire_dls:spatial_dataset_identifier_code>spatial_dataset_identifier_code1</inspire_dls:spatial_dataset_identifier_code>
+ *      <inspire_dls:spatial_dataset_identifier_namespace>spatial_dataset_identifier_namespace1</inspire_dls:spatial_dataset_identifier_namespace>
+ *
+ */
+@Entity
+@DiscriminatorValue("SimpleLayerDatasetIdDataLink")
+public class SimpleLayerDatasetIdDataLink extends OGCLinkToData {
+
+
+    @Column(columnDefinition = "text")
+    private String code;
+
+    @Column(columnDefinition = "text")
+    private String codeSpace;
+
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getCodeSpace() {
+        return codeSpace;
+    }
+
+    public void setCodeSpace(String codeSpace) {
+        this.codeSpace = codeSpace;
+    }
+
+    public SimpleLayerDatasetIdDataLink() {
+        super();
+    }
+
+    public SimpleLayerDatasetIdDataLink(String linkcheckjobid, String sha2, String capabilitiesdocumenttype,
+                                        String ogcLayerName, String code, String codeSpace, DatasetMetadataRecord datasetMetadataRecord) {
+        super(linkcheckjobid,sha2,capabilitiesdocumenttype,datasetMetadataRecord,ogcLayerName);
+        this.code = code;
+        this.codeSpace = codeSpace;
+    }
+
+    @Override
+    public String key() {
+        return super.key() +"::"+getOgcLayerName();
+    }
+
+}

--- a/src/main/java/com/geocat/ingester/model/linkchecker/SimpleLayerMetadataUrlDataLink.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/SimpleLayerMetadataUrlDataLink.java
@@ -1,0 +1,85 @@
+/*
+ *  =============================================================================
+ *  ===  Copyright (C) 2021 Food and Agriculture Organization of the
+ *  ===  United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ *  ===  and United Nations Environment Programme (UNEP)
+ *  ===
+ *  ===  This program is free software; you can redistribute it and/or modify
+ *  ===  it under the terms of the GNU General Public License as published by
+ *  ===  the Free Software Foundation; either version 2 of the License, or (at
+ *  ===  your option) any later version.
+ *  ===
+ *  ===  This program is distributed in the hope that it will be useful, but
+ *  ===  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  ===  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  ===  General Public License for more details.
+ *  ===
+ *  ===  You should have received a copy of the GNU General Public License
+ *  ===  along with this program; if not, write to the Free Software
+ *  ===  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *  ===
+ *  ===  Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ *  ===  Rome - Italy. email: geonetwork@osgeo.org
+ *  ===
+ *  ===  Development of this program was financed by the European Union within
+ *  ===  Service Contract NUMBER – 941143 – IPR – 2021 with subject matter
+ *  ===  "Facilitating a sustainable evolution and maintenance of the INSPIRE
+ *  ===  Geoportal", performed in the period 2021-2023.
+ *  ===
+ *  ===  Contact: JRC Unit B.6 Digital Economy, Via Enrico Fermi 2749,
+ *  ===  21027 Ispra, Italy. email: JRC-INSPIRE-SUPPORT@ec.europa.eu
+ *  ==============================================================================
+ */
+
+package com.geocat.ingester.model.linkchecker;
+
+
+import com.geocat.ingester.model.linkchecker.helper.DatasetMetadataRecord;
+import com.geocat.ingester.model.linkchecker.helper.OGCLinkToData;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+
+/**
+ * Represents a simple linkage between a dataset and layer in an OGC service (WFS/WMS/WMTS).
+ *
+ *     The service (capabilities) can be found using capabilitiesSha2,linkCheckJobId.
+ *     The layer is in ogcLayerName.
+ *
+ *     In the capabilities file, you should find a layer/featuretype (Name=ogcLayerName) that has a metadataURL
+ *     that points the Dataset Metadata document (via fileIdentifier and datasetIdentifier).
+ *
+ */
+@Entity
+@DiscriminatorValue("SimpleLayerMetadataUrlDataLink")
+public class SimpleLayerMetadataUrlDataLink extends OGCLinkToData {
+
+
+    public SimpleLayerMetadataUrlDataLink() {
+        super();
+    }
+
+    public SimpleLayerMetadataUrlDataLink(String linkcheckjobid, String sha2, String capabilitiesdocumenttype, DatasetMetadataRecord datasetMetadataRecord) {
+        super(linkcheckjobid,sha2,capabilitiesdocumenttype,datasetMetadataRecord);
+    }
+
+    //---
+
+
+    //----
+
+
+    @Override
+    public String toString() {
+        return "SimpleLayerMetadataUrlDataLink{\n" +
+                "     ogcLayerName:" + getOgcLayerName() + '\n' +
+                super.toString() +
+                '}';
+    }
+
+    @Override
+    public String key() {
+        return super.key() +"::"+getOgcLayerName();
+    }
+}

--- a/src/main/java/com/geocat/ingester/model/linkchecker/SimpleSpatialDSIDDataLink.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/SimpleSpatialDSIDDataLink.java
@@ -1,0 +1,99 @@
+/*
+ *  =============================================================================
+ *  ===  Copyright (C) 2021 Food and Agriculture Organization of the
+ *  ===  United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ *  ===  and United Nations Environment Programme (UNEP)
+ *  ===
+ *  ===  This program is free software; you can redistribute it and/or modify
+ *  ===  it under the terms of the GNU General Public License as published by
+ *  ===  the Free Software Foundation; either version 2 of the License, or (at
+ *  ===  your option) any later version.
+ *  ===
+ *  ===  This program is distributed in the hope that it will be useful, but
+ *  ===  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  ===  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  ===  General Public License for more details.
+ *  ===
+ *  ===  You should have received a copy of the GNU General Public License
+ *  ===  along with this program; if not, write to the Free Software
+ *  ===  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *  ===
+ *  ===  Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ *  ===  Rome - Italy. email: geonetwork@osgeo.org
+ *  ===
+ *  ===  Development of this program was financed by the European Union within
+ *  ===  Service Contract NUMBER – 941143 – IPR – 2021 with subject matter
+ *  ===  "Facilitating a sustainable evolution and maintenance of the INSPIRE
+ *  ===  Geoportal", performed in the period 2021-2023.
+ *  ===
+ *  ===  Contact: JRC Unit B.6 Digital Economy, Via Enrico Fermi 2749,
+ *  ===  21027 Ispra, Italy. email: JRC-INSPIRE-SUPPORT@ec.europa.eu
+ *  ==============================================================================
+ */
+
+package com.geocat.ingester.model.linkchecker;
+
+
+import com.geocat.ingester.model.linkchecker.helper.DatasetMetadataRecord;
+import com.geocat.ingester.model.linkchecker.helper.OGCLinkToData;
+
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@Entity
+@DiscriminatorValue("SimpleSpatialDSIDDataLink")
+public class SimpleSpatialDSIDDataLink extends OGCLinkToData {
+
+    public SimpleSpatialDSIDDataLink() {
+        super();
+    }
+
+    public SimpleSpatialDSIDDataLink(String linkcheckjobid, String sha2, String capabilitiesdocumenttype, DatasetMetadataRecord datasetMetadataRecord, String layerName) {
+        super(linkcheckjobid,sha2,capabilitiesdocumenttype,datasetMetadataRecord,layerName);
+     }
+
+    @Column(columnDefinition = "text")
+    private String code;
+
+    @Column(columnDefinition = "text")
+    private String codeSpace;
+
+
+    //---
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getCodeSpace() {
+        return codeSpace;
+    }
+
+    public void setCodeSpace(String codeSpace) {
+        this.codeSpace = codeSpace;
+    }
+
+
+//----
+
+
+    @Override
+    public String toString() {
+        return "SimpleSpatialDSIDDataLink{\n" +
+                super.toString() +
+                "code='" + code + '\'' +
+                ", codeSpace='" + codeSpace + '\'' +
+                '}';
+    }
+
+    @Override
+    public String key() {
+        return super.key() +"::"+getOgcLayerName();
+    }
+
+}

--- a/src/main/java/com/geocat/ingester/model/linkchecker/SimpleSpatialDSIDDataLink.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/SimpleSpatialDSIDDataLink.java
@@ -33,7 +33,6 @@
 
 package com.geocat.ingester.model.linkchecker;
 
-
 import com.geocat.ingester.model.linkchecker.helper.DatasetMetadataRecord;
 import com.geocat.ingester.model.linkchecker.helper.OGCLinkToData;
 
@@ -51,7 +50,7 @@ public class SimpleSpatialDSIDDataLink extends OGCLinkToData {
 
     public SimpleSpatialDSIDDataLink(String linkcheckjobid, String sha2, String capabilitiesdocumenttype, DatasetMetadataRecord datasetMetadataRecord, String layerName) {
         super(linkcheckjobid,sha2,capabilitiesdocumenttype,datasetMetadataRecord,layerName);
-     }
+    }
 
     @Column(columnDefinition = "text")
     private String code;

--- a/src/main/java/com/geocat/ingester/model/linkchecker/SimpleStoredQueryDataLink.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/SimpleStoredQueryDataLink.java
@@ -33,11 +33,14 @@
 
 package com.geocat.ingester.model.linkchecker;
 
-
 import com.geocat.ingester.model.linkchecker.helper.DatasetMetadataRecord;
 import com.geocat.ingester.model.linkchecker.helper.LinkToData;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.OneToOne;
 
 @Entity
 @DiscriminatorValue("SimpleStoredQueryDataLink")

--- a/src/main/java/com/geocat/ingester/model/linkchecker/SimpleStoredQueryDataLink.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/SimpleStoredQueryDataLink.java
@@ -1,0 +1,118 @@
+/*
+ *  =============================================================================
+ *  ===  Copyright (C) 2021 Food and Agriculture Organization of the
+ *  ===  United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ *  ===  and United Nations Environment Programme (UNEP)
+ *  ===
+ *  ===  This program is free software; you can redistribute it and/or modify
+ *  ===  it under the terms of the GNU General Public License as published by
+ *  ===  the Free Software Foundation; either version 2 of the License, or (at
+ *  ===  your option) any later version.
+ *  ===
+ *  ===  This program is distributed in the hope that it will be useful, but
+ *  ===  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  ===  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  ===  General Public License for more details.
+ *  ===
+ *  ===  You should have received a copy of the GNU General Public License
+ *  ===  along with this program; if not, write to the Free Software
+ *  ===  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *  ===
+ *  ===  Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ *  ===  Rome - Italy. email: geonetwork@osgeo.org
+ *  ===
+ *  ===  Development of this program was financed by the European Union within
+ *  ===  Service Contract NUMBER – 941143 – IPR – 2021 with subject matter
+ *  ===  "Facilitating a sustainable evolution and maintenance of the INSPIRE
+ *  ===  Geoportal", performed in the period 2021-2023.
+ *  ===
+ *  ===  Contact: JRC Unit B.6 Digital Economy, Via Enrico Fermi 2749,
+ *  ===  21027 Ispra, Italy. email: JRC-INSPIRE-SUPPORT@ec.europa.eu
+ *  ==============================================================================
+ */
+
+package com.geocat.ingester.model.linkchecker;
+
+
+import com.geocat.ingester.model.linkchecker.helper.DatasetMetadataRecord;
+import com.geocat.ingester.model.linkchecker.helper.LinkToData;
+
+import javax.persistence.*;
+
+@Entity
+@DiscriminatorValue("SimpleStoredQueryDataLink")
+public class SimpleStoredQueryDataLink extends LinkToData {
+
+    @Column(columnDefinition = "text")
+    private String storedProcName;
+
+    @Column(columnDefinition = "text")
+    private String code;
+
+    @Column(columnDefinition = "text")
+    private String codeSpace;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    OGCRequest ogcRequest; // might be null
+
+
+    public SimpleStoredQueryDataLink() {
+        super();
+    }
+
+    public SimpleStoredQueryDataLink(String linkcheckjobid, String sha2, String capabilitiesdocumenttype, DatasetMetadataRecord datasetMetadataRecord) {
+        super(linkcheckjobid,sha2,capabilitiesdocumenttype,datasetMetadataRecord);
+    }
+
+    //----
+
+
+    public OGCRequest getOgcRequest() {
+        return ogcRequest;
+    }
+
+    public void setOgcRequest(OGCRequest ogcRequest) {
+        this.ogcRequest = ogcRequest;
+    }
+
+    public String getStoredProcName() {
+        return storedProcName;
+    }
+
+    public void setStoredProcName(String storedProcName) {
+        this.storedProcName = storedProcName;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getCodeSpace() {
+        return codeSpace;
+    }
+
+    public void setCodeSpace(String codeSpace) {
+        this.codeSpace = codeSpace;
+    }
+
+    //--
+
+    @Override
+    public String toString() {
+        return "SimpleStoredQueryDataLink{" + "\n"+
+                "     storedProcName: " + storedProcName + "\n" +
+                "     code: " + code + "\n" +
+                "     codeSpace: " + codeSpace + "\n" +
+                super.toString() + "\n" +
+                '}';
+    }
+
+    @Override
+    public String key() {
+        return super.key() +"::storedquery::"+storedProcName;
+    }
+}

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/AtomDataRequest.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/AtomDataRequest.java
@@ -36,7 +36,13 @@ package com.geocat.ingester.model.linkchecker.helper;
 
 import com.geocat.ingester.model.linkchecker.AtomActualDataEntry;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
 
 import static com.geocat.ingester.model.linkchecker.helper.PartialDownloadHint.ALWAYS_PARTIAL;
 

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/AtomDataRequest.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/AtomDataRequest.java
@@ -1,0 +1,91 @@
+/*
+ *  =============================================================================
+ *  ===  Copyright (C) 2021 Food and Agriculture Organization of the
+ *  ===  United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ *  ===  and United Nations Environment Programme (UNEP)
+ *  ===
+ *  ===  This program is free software; you can redistribute it and/or modify
+ *  ===  it under the terms of the GNU General Public License as published by
+ *  ===  the Free Software Foundation; either version 2 of the License, or (at
+ *  ===  your option) any later version.
+ *  ===
+ *  ===  This program is distributed in the hope that it will be useful, but
+ *  ===  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  ===  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  ===  General Public License for more details.
+ *  ===
+ *  ===  You should have received a copy of the GNU General Public License
+ *  ===  along with this program; if not, write to the Free Software
+ *  ===  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *  ===
+ *  ===  Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ *  ===  Rome - Italy. email: geonetwork@osgeo.org
+ *  ===
+ *  ===  Development of this program was financed by the European Union within
+ *  ===  Service Contract NUMBER – 941143 – IPR – 2021 with subject matter
+ *  ===  "Facilitating a sustainable evolution and maintenance of the INSPIRE
+ *  ===  Geoportal", performed in the period 2021-2023.
+ *  ===
+ *  ===  Contact: JRC Unit B.6 Digital Economy, Via Enrico Fermi 2749,
+ *  ===  21027 Ispra, Italy. email: JRC-INSPIRE-SUPPORT@ec.europa.eu
+ *  ==============================================================================
+ */
+
+package com.geocat.ingester.model.linkchecker.helper;
+
+
+import com.geocat.ingester.model.linkchecker.AtomActualDataEntry;
+
+import javax.persistence.*;
+
+import static com.geocat.ingester.model.linkchecker.helper.PartialDownloadHint.ALWAYS_PARTIAL;
+
+
+@Entity
+public class AtomDataRequest extends RetrievableSimpleLink  {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private long atomDataRequestId;
+
+
+    @ManyToOne(fetch = FetchType.EAGER,cascade = {CascadeType.PERSIST,CascadeType.MERGE})
+    AtomActualDataEntry atomActualDataEntry;
+
+    Boolean successfullyDownloaded;
+
+
+    public AtomDataRequest() {
+        super();
+        setPartialDownloadHint(ALWAYS_PARTIAL);
+    }
+
+    public AtomDataRequest(String url ) {
+        this();
+        setRawURL(url);
+        setFixedURL(url);
+    }
+
+    public AtomActualDataEntry getAtomActualDataEntry() {
+        return atomActualDataEntry;
+    }
+
+    public void setAtomActualDataEntry(AtomActualDataEntry atomActualDataEntry) {
+        this.atomActualDataEntry = atomActualDataEntry;
+    }
+
+    public long getAtomDataRequestId() {
+        return atomDataRequestId;
+    }
+
+    public void setAtomDataRequestId(long atomDataRequestId) {
+        this.atomDataRequestId = atomDataRequestId;
+    }
+
+    public Boolean getSuccessfullyDownloaded() {
+        return successfullyDownloaded;
+    }
+
+    public void setSuccessfullyDownloaded(Boolean successfullyDownloaded) {
+        this.successfullyDownloaded = successfullyDownloaded;
+    }
+}

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/AtomSubFeedRequest.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/AtomSubFeedRequest.java
@@ -33,12 +33,28 @@
 
 package com.geocat.ingester.model.linkchecker.helper;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
 import static com.geocat.ingester.model.linkchecker.helper.PartialDownloadHint.CAPABILITIES_ONLY;
 
-
 @Entity
+@Table(
+        indexes = {
+                @Index(
+                        name = "AtomSubFeedRequest_linkcheckid_idx",
+                        columnList = "linkcheckjobid",
+                        unique = false
+                )
+        })
 public class AtomSubFeedRequest extends RetrievableSimpleLink  {
 
     @Id
@@ -63,9 +79,9 @@ public class AtomSubFeedRequest extends RetrievableSimpleLink  {
         this();
         setRawURL(url);
         setFixedURL(url);
-     }
+    }
 
-     //--
+    //--
 
     public long getAtomSubFeedRequestId() {
         return atomSubFeedRequestId;

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/AtomSubFeedRequest.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/AtomSubFeedRequest.java
@@ -1,0 +1,93 @@
+/*
+ *  =============================================================================
+ *  ===  Copyright (C) 2021 Food and Agriculture Organization of the
+ *  ===  United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ *  ===  and United Nations Environment Programme (UNEP)
+ *  ===
+ *  ===  This program is free software; you can redistribute it and/or modify
+ *  ===  it under the terms of the GNU General Public License as published by
+ *  ===  the Free Software Foundation; either version 2 of the License, or (at
+ *  ===  your option) any later version.
+ *  ===
+ *  ===  This program is distributed in the hope that it will be useful, but
+ *  ===  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  ===  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  ===  General Public License for more details.
+ *  ===
+ *  ===  You should have received a copy of the GNU General Public License
+ *  ===  along with this program; if not, write to the Free Software
+ *  ===  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *  ===
+ *  ===  Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ *  ===  Rome - Italy. email: geonetwork@osgeo.org
+ *  ===
+ *  ===  Development of this program was financed by the European Union within
+ *  ===  Service Contract NUMBER – 941143 – IPR – 2021 with subject matter
+ *  ===  "Facilitating a sustainable evolution and maintenance of the INSPIRE
+ *  ===  Geoportal", performed in the period 2021-2023.
+ *  ===
+ *  ===  Contact: JRC Unit B.6 Digital Economy, Via Enrico Fermi 2749,
+ *  ===  21027 Ispra, Italy. email: JRC-INSPIRE-SUPPORT@ec.europa.eu
+ *  ==============================================================================
+ */
+
+package com.geocat.ingester.model.linkchecker.helper;
+
+import javax.persistence.*;
+
+import static com.geocat.ingester.model.linkchecker.helper.PartialDownloadHint.CAPABILITIES_ONLY;
+
+
+@Entity
+public class AtomSubFeedRequest extends RetrievableSimpleLink  {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private long atomSubFeedRequestId;
+
+//    @OneToOne(mappedBy = "atomSubFeedRequest")
+//    LinkToData linkToData;
+
+    Boolean successfulAtomRequest;
+
+    @Column(columnDefinition = "text")
+    String unSuccessfulAtomRequestReason;
+
+
+    public AtomSubFeedRequest() {
+        super();
+        setPartialDownloadHint(CAPABILITIES_ONLY);
+    }
+
+    public AtomSubFeedRequest(String url ) {
+        this();
+        setRawURL(url);
+        setFixedURL(url);
+     }
+
+     //--
+
+    public long getAtomSubFeedRequestId() {
+        return atomSubFeedRequestId;
+    }
+
+    public void setAtomSubFeedRequestId(long atomSubFeedRequestId) {
+        this.atomSubFeedRequestId = atomSubFeedRequestId;
+    }
+
+    public Boolean getSuccessfulAtomRequest() {
+        return successfulAtomRequest;
+    }
+
+    public void setSuccessfulAtomRequest(Boolean successfulAtomRequest) {
+        this.successfulAtomRequest = successfulAtomRequest;
+    }
+
+    public String getUnSuccessfulAtomRequestReason() {
+        return unSuccessfulAtomRequestReason;
+    }
+
+    public void setUnSuccessfulAtomRequestReason(String unSuccessfulAtomRequestReason) {
+        this.unSuccessfulAtomRequestReason = unSuccessfulAtomRequestReason;
+    }
+}

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/CapabilitiesDatasetMetadataLinkDatasetIdentifier.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/CapabilitiesDatasetMetadataLinkDatasetIdentifier.java
@@ -33,9 +33,14 @@
 
 package com.geocat.ingester.model.linkchecker.helper;
 
+
 import com.geocat.ingester.model.linkchecker.CapabilitiesDatasetMetadataLink;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToOne;
 
 
 @Entity
@@ -54,7 +59,7 @@ public class CapabilitiesDatasetMetadataLinkDatasetIdentifier extends DatasetIde
     public CapabilitiesDatasetMetadataLinkDatasetIdentifier(DatasetIdentifier id) {
         super(id.getIdentifierNodeType(),id.getCode(),id.getCodeSpace());
     }
-    public CapabilitiesDatasetMetadataLinkDatasetIdentifier(DatasetIdentifier id, CapabilitiesDatasetMetadataLink r ) {
+    public CapabilitiesDatasetMetadataLinkDatasetIdentifier(DatasetIdentifier id,CapabilitiesDatasetMetadataLink r ) {
         this(id);
         this.capDatasetMetadataLink = r;
     }

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/DatasetIdentifier.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/DatasetIdentifier.java
@@ -33,9 +33,23 @@
 
 package com.geocat.ingester.model.linkchecker.helper;
 
-import com.geocat.ingester.model.linkchecker.helper.DatasetIdentifierNodeType;
-
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinColumns;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 @Entity
 @Table(
@@ -49,6 +63,16 @@ import javax.persistence.*;
                 @Index(
                         name = "dsid_cap",
                         columnList = "capdatasetmetadatalink_capabilitiesdatasetmetadatalinkid",
+                        unique = false
+                ),
+                @Index(
+                        name = "dsid_code_idx",
+                        columnList = "code",
+                        unique = false
+                ),
+                @Index(
+                        name = "ops_on_idx",
+                        columnList = "operatesOnLink_operatesOnLinkId",
                         unique = false
                 )
         })
@@ -74,17 +98,17 @@ public class DatasetIdentifier {
 
 
 
+
     //---
     public DatasetIdentifier() {}
 
-    public DatasetIdentifier(DatasetIdentifierNodeType identifierNodeType, String code, String codeSpace) {
+    public DatasetIdentifier(DatasetIdentifierNodeType identifierNodeType, String code, String codeSpace ) {
         this.identifierNodeType = identifierNodeType;
         this.code = code;
         this.codeSpace = codeSpace;
     }
 
     //---
-
 
 
 
@@ -127,10 +151,10 @@ public class DatasetIdentifier {
 
     @Override
     public String toString() {
-        return "DatasetIdentifier{" +
-                "identifierType=" + identifierNodeType +
-                 ", code='" + code +
+        return " " +
+                "(" + identifierNodeType +
+                ") code='" + code +
                 "', codeSpace='" + codeSpace +
-                "'}";
+                "'";
     }
 }

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/DatasetMetadataRecordDatasetIdentifier.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/DatasetMetadataRecordDatasetIdentifier.java
@@ -33,7 +33,11 @@
 
 package com.geocat.ingester.model.linkchecker.helper;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToOne;
 
 @Entity
 @DiscriminatorValue("DDMDRecordDatasetIdentifier")
@@ -52,7 +56,7 @@ public class DatasetMetadataRecordDatasetIdentifier extends DatasetIdentifier{
         super(id.getIdentifierNodeType(),id.getCode(),id.getCodeSpace());
     }
 
-    public DatasetMetadataRecordDatasetIdentifier(DatasetIdentifier id, DatasetMetadataRecord r ) {
+    public DatasetMetadataRecordDatasetIdentifier(DatasetIdentifier id,DatasetMetadataRecord r ) {
         this(id);
         this.datasetMetadataRecord = r;
     }

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/HTTPRequestCheckerType.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/HTTPRequestCheckerType.java
@@ -1,0 +1,40 @@
+/*
+ *  =============================================================================
+ *  ===  Copyright (C) 2021 Food and Agriculture Organization of the
+ *  ===  United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ *  ===  and United Nations Environment Programme (UNEP)
+ *  ===
+ *  ===  This program is free software; you can redistribute it and/or modify
+ *  ===  it under the terms of the GNU General Public License as published by
+ *  ===  the Free Software Foundation; either version 2 of the License, or (at
+ *  ===  your option) any later version.
+ *  ===
+ *  ===  This program is distributed in the hope that it will be useful, but
+ *  ===  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  ===  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  ===  General Public License for more details.
+ *  ===
+ *  ===  You should have received a copy of the GNU General Public License
+ *  ===  along with this program; if not, write to the Free Software
+ *  ===  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *  ===
+ *  ===  Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ *  ===  Rome - Italy. email: geonetwork@osgeo.org
+ *  ===
+ *  ===  Development of this program was financed by the European Union within
+ *  ===  Service Contract NUMBER – 941143 – IPR – 2021 with subject matter
+ *  ===  "Facilitating a sustainable evolution and maintenance of the INSPIRE
+ *  ===  Geoportal", performed in the period 2021-2023.
+ *  ===
+ *  ===  Contact: JRC Unit B.6 Digital Economy, Via Enrico Fermi 2749,
+ *  ===  21027 Ispra, Italy. email: JRC-INSPIRE-SUPPORT@ec.europa.eu
+ *  ==============================================================================
+ */
+
+package com.geocat.ingester.model.linkchecker.helper;
+
+public enum HTTPRequestCheckerType {
+    ANY,
+    IMAGE_ONLY,
+    FEATURE_COLLECTION_ONLY
+}

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/LinkToData.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/LinkToData.java
@@ -33,11 +33,30 @@
 
 package com.geocat.ingester.model.linkchecker.helper;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
 
 @Entity(name="linktodata")
 @Table(
@@ -47,7 +66,7 @@ import java.util.Map;
 //                        columnList = "datasetmetadatarecord_datasetmetadatadocumentid",
 //                        unique = false
 //                ),
-/*                @Index(
+                @Index(
                         name = "link2data_ogcrequest_ogcrequestid_idx",
                         columnList = "ogcrequest_ogcrequestid",
                         unique = false
@@ -61,7 +80,17 @@ import java.util.Map;
                         name = "link2data_linkcheckjobid_idx",
                         columnList = "linkcheckjobid",
                         unique = false
-                )*/
+                ),
+                @Index(
+                        name = "link2data_linktodata_id_idx",
+                        columnList = "linktodata_id",
+                        unique = false
+                ),
+                @Index(
+                        name = "link2data_linkcheckjobid_datasetmetadatafileidentifier_idx",
+                        columnList = "linkcheckjobid,datasetmetadatafileidentifier",
+                        unique = false
+                )
         })
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "linkType",
@@ -101,10 +130,10 @@ public class LinkToData {
     public LinkToData() {
     }
 
-    public LinkToData(String linkcheckjobid, String sha2, String capabilitiesdocumenttype, DatasetMetadataRecord datasetMetadataRecord) {
+    public LinkToData(String linkcheckjobid, String sha2, String capabilitiesdocumenttype,DatasetMetadataRecord datasetMetadataRecord) {
         this.linkCheckJobId = linkcheckjobid;
         this.capabilitiesSha2 = sha2;
-       // this.datasetMetadataRecord = datasetMetadataRecord;
+        // this.datasetMetadataRecord = datasetMetadataRecord;
         if (datasetMetadataRecord !=null)
             this.datasetMetadataFileIdentifier = datasetMetadataRecord.getFileIdentifier();
         if  ( (capabilitiesdocumenttype !=null) && (!capabilitiesdocumenttype.isEmpty()))
@@ -199,17 +228,17 @@ public class LinkToData {
                 "     capabilitiesDocumentType: " + capabilitiesDocumentType+ "\n" ;
     }
 
-   public String key() {
+    public String key() {
         return linkCheckJobId + "::"+capabilitiesSha2;
-   }
+    }
 
 
     public static List<LinkToData> unique(List<LinkToData> all) {
         Map<String,LinkToData> result = new HashMap<>();
         for (LinkToData link :all ){
-                String hash = link.key();
-                if (!result.containsKey(hash))
-                    result.put(hash, link);
+            String hash = link.key();
+            if (!result.containsKey(hash))
+                result.put(hash, link);
         }
         return new ArrayList(result.values());
     }

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/LinkToData.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/LinkToData.java
@@ -39,7 +39,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-
 @Entity(name="linktodata")
 @Table(
         indexes = {

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/OGCLinkToData.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/OGCLinkToData.java
@@ -1,0 +1,96 @@
+/*
+ *  =============================================================================
+ *  ===  Copyright (C) 2021 Food and Agriculture Organization of the
+ *  ===  United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ *  ===  and United Nations Environment Programme (UNEP)
+ *  ===
+ *  ===  This program is free software; you can redistribute it and/or modify
+ *  ===  it under the terms of the GNU General Public License as published by
+ *  ===  the Free Software Foundation; either version 2 of the License, or (at
+ *  ===  your option) any later version.
+ *  ===
+ *  ===  This program is distributed in the hope that it will be useful, but
+ *  ===  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  ===  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  ===  General Public License for more details.
+ *  ===
+ *  ===  You should have received a copy of the GNU General Public License
+ *  ===  along with this program; if not, write to the Free Software
+ *  ===  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *  ===
+ *  ===  Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ *  ===  Rome - Italy. email: geonetwork@osgeo.org
+ *  ===
+ *  ===  Development of this program was financed by the European Union within
+ *  ===  Service Contract NUMBER – 941143 – IPR – 2021 with subject matter
+ *  ===  "Facilitating a sustainable evolution and maintenance of the INSPIRE
+ *  ===  Geoportal", performed in the period 2021-2023.
+ *  ===
+ *  ===  Contact: JRC Unit B.6 Digital Economy, Via Enrico Fermi 2749,
+ *  ===  21027 Ispra, Italy. email: JRC-INSPIRE-SUPPORT@ec.europa.eu
+ *  ==============================================================================
+ */
+
+package com.geocat.ingester.model.linkchecker.helper;
+
+import com.geocat.ingester.model.linkchecker.OGCRequest;
+import org.hibernate.annotations.*;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.*;
+
+@Entity
+@DiscriminatorValue("OGCLinkToData")
+public class OGCLinkToData extends LinkToData {
+
+    @OneToOne(cascade = CascadeType.ALL,
+    fetch = FetchType.EAGER)
+    @Fetch(value = FetchMode.JOIN)
+    @BatchSize(size=500)
+    @JoinColumn(name="ogcrequest_ogcrequestid")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    OGCRequest ogcRequest; // might be null
+
+    @Column(columnDefinition = "text")
+    private String ogcLayerName;  //for simple (getmap/getfeature) WFS/WMS/WMTS, this is the Layer/FeatureType name
+
+    //--
+
+
+    public OGCLinkToData() {
+        super();
+    }
+
+    public OGCLinkToData(String linkcheckjobid, String sha2, String capabilitiesdocumenttype, DatasetMetadataRecord datasetMetadataRecord, String ogcLayerName) {
+        super(linkcheckjobid, sha2, capabilitiesdocumenttype, datasetMetadataRecord);
+        this.ogcLayerName = ogcLayerName;
+    }
+
+    public OGCLinkToData(String linkcheckjobid, String sha2, String capabilitiesdocumenttype, DatasetMetadataRecord datasetMetadataRecord ) {
+        super(linkcheckjobid, sha2, capabilitiesdocumenttype, datasetMetadataRecord);
+     }
+
+    @Override
+    public String key() {
+        return super.key() +"::"+getOgcLayerName();
+    }
+
+
+    public OGCRequest getOgcRequest() {
+        return ogcRequest;
+    }
+
+
+    public void setOgcRequest(OGCRequest ogcRequest) {
+        this.ogcRequest = ogcRequest;
+    }
+
+    public String getOgcLayerName() {
+        return ogcLayerName;
+    }
+
+    public void setOgcLayerName(String ogcLayerName) {
+        this.ogcLayerName = ogcLayerName;
+    }
+}

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/OGCLinkToData.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/OGCLinkToData.java
@@ -34,22 +34,31 @@
 package com.geocat.ingester.model.linkchecker.helper;
 
 import com.geocat.ingester.model.linkchecker.OGCRequest;
-import org.hibernate.annotations.*;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
-import javax.persistence.*;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
 
 @Entity
 @DiscriminatorValue("OGCLinkToData")
 public class OGCLinkToData extends LinkToData {
 
     @OneToOne(cascade = CascadeType.ALL,
-    fetch = FetchType.EAGER)
+            fetch = FetchType.EAGER)
     @Fetch(value = FetchMode.JOIN)
     @BatchSize(size=500)
     @JoinColumn(name="ogcrequest_ogcrequestid")
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    // @OnDelete(action = OnDeleteAction.CASCADE)
     OGCRequest ogcRequest; // might be null
 
     @Column(columnDefinition = "text")
@@ -69,7 +78,7 @@ public class OGCLinkToData extends LinkToData {
 
     public OGCLinkToData(String linkcheckjobid, String sha2, String capabilitiesdocumenttype, DatasetMetadataRecord datasetMetadataRecord ) {
         super(linkcheckjobid, sha2, capabilitiesdocumenttype, datasetMetadataRecord);
-     }
+    }
 
     @Override
     public String key() {

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/OperatesOnLinkDatasetIdentifier.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/OperatesOnLinkDatasetIdentifier.java
@@ -35,12 +35,16 @@ package com.geocat.ingester.model.linkchecker.helper;
 
 import com.geocat.ingester.model.linkchecker.OperatesOnLink;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToOne;
 
 
 @Entity
 @DiscriminatorValue("OperatesOnLnkDatasetIdentifier")
-public class OperatesOnLinkDatasetIdentifier extends DatasetIdentifier{
+public class OperatesOnLinkDatasetIdentifier extends DatasetIdentifier {
 
     @ManyToOne(fetch = FetchType.EAGER,cascade = {CascadeType.PERSIST,CascadeType.MERGE})
     OperatesOnLink operatesOnLink;

--- a/src/main/java/com/geocat/ingester/model/linkchecker/helper/ServiceMetadataRecord.java
+++ b/src/main/java/com/geocat/ingester/model/linkchecker/helper/ServiceMetadataRecord.java
@@ -61,6 +61,17 @@ import java.util.Set;
                         name = "ServiceMetadataRecord_sha2_linkcheckjobid",
                         columnList = "sha2,linkCheckJobId",
                         unique = false
+                ),
+                @Index(
+                        name = "ServiceMetadataRecord_fileIdentifier_linkcheckjobid",
+                        columnList = "fileidentifier,linkcheckjobid",
+                        unique = false
+                )
+                ,
+                @Index(
+                        name = "ServiceMetadataRecord_job_type_state_idx",
+                        columnList = "linkcheckjobid,service_record_type,state",
+                        unique = false
                 )
         }
 )
@@ -88,7 +99,7 @@ public class ServiceMetadataRecord extends MetadataRecord {
             cascade = {CascadeType.ALL}, fetch = FetchType.EAGER)
     // @JoinColumn(name="serviceMetadataRecordId")
     @Fetch(value = FetchMode.SUBSELECT)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    // @OnDelete(action = OnDeleteAction.CASCADE)
     private Set<ServiceDocumentLink> serviceDocumentLinks;
 
     //OperatesOn Links (likely to dataset metadata documents) found in this service document.
@@ -96,7 +107,7 @@ public class ServiceMetadataRecord extends MetadataRecord {
             cascade = {CascadeType.ALL}, fetch = FetchType.EAGER)
     // @JoinColumn(name="serviceMetadataRecordId")
     @Fetch(value = FetchMode.SUBSELECT)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    // @OnDelete(action = OnDeleteAction.CASCADE)
     private Set<OperatesOnLink> operatesOnLinks;
 
 

--- a/src/main/java/com/geocat/ingester/model/metadata/Metadata.java
+++ b/src/main/java/com/geocat/ingester/model/metadata/Metadata.java
@@ -71,7 +71,7 @@ public class Metadata implements Serializable {
     @OneToMany(mappedBy="id.metadataId",  fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     private Set<OperationAllowed> privileges = new HashSet<OperationAllowed>();
 
-    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name="metadata_id", nullable=false)
     private Set<MetadataIndicator> indicators = new HashSet<MetadataIndicator>();
 

--- a/src/main/java/com/geocat/ingester/model/metadata/MetadataIndicator.java
+++ b/src/main/java/com/geocat/ingester/model/metadata/MetadataIndicator.java
@@ -2,14 +2,8 @@ package com.geocat.ingester.model.metadata;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
+
+import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -24,5 +18,7 @@ public class MetadataIndicator implements Serializable {
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = ID_SEQ_NAME)
     private int id;
     private String name;
+
+    @Column(columnDefinition = "text")
     private String value;
 }

--- a/src/main/java/com/geocat/ingester/service/IngesterService.java
+++ b/src/main/java/com/geocat/ingester/service/IngesterService.java
@@ -18,10 +18,7 @@ import com.geocat.ingester.model.linkchecker.LinkCheckJob;
 import com.geocat.ingester.model.linkchecker.LocalDatasetMetadataRecord;
 import com.geocat.ingester.model.linkchecker.LocalServiceMetadataRecord;
 import com.geocat.ingester.model.linkchecker.ServiceDocumentLink;
-import com.geocat.ingester.model.linkchecker.helper.CapabilitiesType;
-import com.geocat.ingester.model.linkchecker.helper.IndicatorStatus;
-import com.geocat.ingester.model.linkchecker.helper.LinkToData;
-import com.geocat.ingester.model.linkchecker.helper.ServiceMetadataRecord;
+import com.geocat.ingester.model.linkchecker.helper.*;
 import com.geocat.ingester.model.metadata.HarvesterConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -383,6 +380,12 @@ public class IngesterService {
                     String capabilitiesSha2 = vl.getCapabilitiesSha2();
 
                     Optional<ServiceDocumentLink> serviceDocumentLink = serviceDocumentLinkRepo.findFirstByLinkCheckJobIdAndSha2(linkCheckJobId, capabilitiesSha2);
+
+                    if (vl instanceof OGCLinkToData) {
+                        OGCLinkToData ogcLinkToData = (OGCLinkToData) vl;
+                        addIndicator(metadata, "INDICATOR_VIEW_SERVICE_LAYERNAME", ogcLinkToData.getOgcLayerName());
+                        addIndicator(metadata, "INDICATOR_VIEW_SERVICE_LAYERLINK", ogcLinkToData.getOgcRequest().getFinalURL());
+                    }
 
                     if (serviceDocumentLink.isPresent()) {
                         ServiceMetadataRecord serviceMetadataRecord = serviceDocumentLink.get().getLocalServiceMetadataRecord();


### PR DESCRIPTION
Added the following indicators to the dataset metadata:

1) For WMS / WMTS services linking the dataset: 

  - `INDICATOR_VIEW_SERVICE_IDENTIFIER`: Service metadata file identifier
  - `INDICATOR_VIEW_SERVICE_LAYERNAME`: WMS/WMTS layer name
  - `INDICATOR_VIEW_SERVICE_LAYERLINK`: WMS/WMTS layer URL

2) For Atom / WFS services linking the dataset: 

  - `INDICATOR_VIEW_SERVICE_IDENTIFIER`: Service metadata file identifier
  - `INDICATOR_DOWNLOAD_SERVICE_LAYERLINK`
  - `INDICATOR_DOWNLOAD_SERVICE_LAYERNAME`
